### PR TITLE
Increase file size limit from 1MB to 3MB

### DIFF
--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -28,7 +28,7 @@ class FilesController < ApplicationController
     end
 
     if presign_params[:file_size].to_i > S3PresignService::MAX_FILE_SIZE
-      render json: { error: "File size exceeds 1MB limit." }, status: :unprocessable_entity
+      render json: { error: "File size exceeds 3MB limit." }, status: :unprocessable_entity
     end
   end
 end

--- a/app/javascript/controllers/files_controller.js
+++ b/app/javascript/controllers/files_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 
-const MAX_FILE_SIZE = 1 * 1024 * 1024 // 1MB
+const MAX_FILE_SIZE = 3 * 1024 * 1024 // 3MB
 const ALLOWED_TYPES = [
   "image/jpeg",
   "image/png",
@@ -57,7 +57,7 @@ export default class extends Controller {
       return "Invalid file type. Only images (JPEG, PNG, GIF, WebP) and PDFs are allowed."
     }
     if (file.size > MAX_FILE_SIZE) {
-      return "File size exceeds 1MB limit."
+      return "File size exceeds 3MB limit."
     }
     return null
   }

--- a/app/services/s3_presign_service.rb
+++ b/app/services/s3_presign_service.rb
@@ -1,5 +1,5 @@
 class S3PresignService
-  MAX_FILE_SIZE = 1.megabyte
+  MAX_FILE_SIZE = 3.megabytes
   ALLOWED_CONTENT_TYPES = %w[
     image/jpeg
     image/png

--- a/app/views/files/index.html.erb
+++ b/app/views/files/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Upload a file</h1>
 
 <div data-controller="files">
-  <p>Accepted formats: JPEG, PNG, GIF, WebP, PDF (max 1MB)</p>
+  <p>Accepted formats: JPEG, PNG, GIF, WebP, PDF (max 3MB)</p>
 
   <input type="file"
          data-files-target="fileInput"

--- a/test/controllers/files_controller_test.rb
+++ b/test/controllers/files_controller_test.rb
@@ -42,11 +42,11 @@ class FilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "presigned_url rejects file exceeding size limit" do
-    post presigned_url_files_url, params: { filename: "big.png", content_type: "image/png", file_size: 2_000_000 }, as: :json
+    post presigned_url_files_url, params: { filename: "big.png", content_type: "image/png", file_size: 4_000_000 }, as: :json
 
     assert_response :unprocessable_entity
     json = JSON.parse(response.body)
-    assert_match(/1MB/i, json["error"])
+    assert_match(/3MB/i, json["error"])
   end
 
   test "presigned_url rejects missing parameters" do

--- a/test/services/s3_presign_service_test.rb
+++ b/test/services/s3_presign_service_test.rb
@@ -29,8 +29,8 @@ class S3PresignServiceTest < ActiveSupport::TestCase
     assert_not S3PresignService.valid_content_type?("application/zip")
   end
 
-  test "MAX_FILE_SIZE is 1 megabyte" do
-    assert_equal 1.megabyte, S3PresignService::MAX_FILE_SIZE
+  test "MAX_FILE_SIZE is 3 megabytes" do
+    assert_equal 3.megabytes, S3PresignService::MAX_FILE_SIZE
   end
 
   test "presigned_url returns url and fields" do
@@ -42,7 +42,7 @@ class S3PresignServiceTest < ActiveSupport::TestCase
     mock_bucket.expect(:presigned_post, mock_post) do |**kwargs|
       kwargs[:key].is_a?(String) &&
         kwargs[:content_type] == "image/png" &&
-        kwargs[:content_length_range] == (1..1.megabyte)
+        kwargs[:content_length_range] == (1..3.megabytes)
     end
 
     service = S3PresignService.new(bucket: mock_bucket)


### PR DESCRIPTION
## Summary
- Increase `MAX_FILE_SIZE` from 1MB to 3MB in `S3PresignService`
- Update error messages in controller and JS to reference 3MB
- Update the view to show "max 3MB"
- Update tests to reflect the new limit

## Files changed
- `app/services/s3_presign_service.rb` - constant and presigned post range
- `app/controllers/files_controller.rb` - error message
- `app/javascript/controllers/files_controller.js` - client-side constant and error message
- `app/views/files/index.html.erb` - display text
- `test/services/s3_presign_service_test.rb` - updated assertions
- `test/controllers/files_controller_test.rb` - updated test file size and error match

## Test plan
- [x] CI passes (lint, security scan, tests)
- [x] Files under 3MB are accepted
- [x] Files over 3MB are rejected with correct error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)