### PR TITLE
Increase file size limit from 3MB to 10MB

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (8.0.2)
+    brakeman (8.0.4)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/app/controllers/files_controller.rb
+++ b/app/controllers/files_controller.rb
@@ -28,7 +28,7 @@ class FilesController < ApplicationController
     end
 
     if presign_params[:file_size].to_i > S3PresignService::MAX_FILE_SIZE
-      render json: { error: "File size exceeds 3MB limit." }, status: :unprocessable_entity
+      render json: { error: "File size exceeds 10MB limit." }, status: :unprocessable_entity
     end
   end
 end

--- a/app/javascript/controllers/files_controller.js
+++ b/app/javascript/controllers/files_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 
-const MAX_FILE_SIZE = 3 * 1024 * 1024 // 3MB
+const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
 const ALLOWED_TYPES = [
   "image/jpeg",
   "image/png",
@@ -57,7 +57,7 @@ export default class extends Controller {
       return "Invalid file type. Only images (JPEG, PNG, GIF, WebP) and PDFs are allowed."
     }
     if (file.size > MAX_FILE_SIZE) {
-      return "File size exceeds 3MB limit."
+      return "File size exceeds 10MB limit."
     }
     return null
   }

--- a/app/services/s3_presign_service.rb
+++ b/app/services/s3_presign_service.rb
@@ -1,5 +1,5 @@
 class S3PresignService
-  MAX_FILE_SIZE = 3.megabytes
+  MAX_FILE_SIZE = 10.megabytes
   ALLOWED_CONTENT_TYPES = %w[
     image/jpeg
     image/png

--- a/app/views/files/index.html.erb
+++ b/app/views/files/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Upload a file</h1>
 
 <div data-controller="files">
-  <p>Accepted formats: JPEG, PNG, GIF, WebP, PDF (max 3MB)</p>
+  <p>Accepted formats: JPEG, PNG, GIF, WebP, PDF (max 10MB)</p>
 
   <input type="file"
          data-files-target="fileInput"

--- a/test/controllers/files_controller_test.rb
+++ b/test/controllers/files_controller_test.rb
@@ -42,11 +42,11 @@ class FilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "presigned_url rejects file exceeding size limit" do
-    post presigned_url_files_url, params: { filename: "big.png", content_type: "image/png", file_size: 4_000_000 }, as: :json
+    post presigned_url_files_url, params: { filename: "big.png", content_type: "image/png", file_size: 11_000_000 }, as: :json
 
     assert_response :unprocessable_entity
     json = JSON.parse(response.body)
-    assert_match(/3MB/i, json["error"])
+    assert_match(/10MB/i, json["error"])
   end
 
   test "presigned_url rejects missing parameters" do

--- a/test/services/s3_presign_service_test.rb
+++ b/test/services/s3_presign_service_test.rb
@@ -29,8 +29,8 @@ class S3PresignServiceTest < ActiveSupport::TestCase
     assert_not S3PresignService.valid_content_type?("application/zip")
   end
 
-  test "MAX_FILE_SIZE is 3 megabytes" do
-    assert_equal 3.megabytes, S3PresignService::MAX_FILE_SIZE
+  test "MAX_FILE_SIZE is 10 megabytes" do
+    assert_equal 10.megabytes, S3PresignService::MAX_FILE_SIZE
   end
 
   test "presigned_url returns url and fields" do
@@ -42,7 +42,7 @@ class S3PresignServiceTest < ActiveSupport::TestCase
     mock_bucket.expect(:presigned_post, mock_post) do |**kwargs|
       kwargs[:key].is_a?(String) &&
         kwargs[:content_type] == "image/png" &&
-        kwargs[:content_length_range] == (1..3.megabytes)
+        kwargs[:content_length_range] == (1..10.megabytes)
     end
 
     service = S3PresignService.new(bucket: mock_bucket)


### PR DESCRIPTION
## Summary
- Increase `MAX_FILE_SIZE` from 3MB to 10MB across backend, frontend, and tests
- Updates error messages and display text to reference 10MB

## Test plan
- [x] CI passes (lint, security scan, tests)
- [x] Files under 10MB are accepted
- [ ] Files over 10MB are rejected with correct error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)